### PR TITLE
Fixed issue preventing actually cached tokens from being returned

### DIFF
--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessTokenProvider.cs
@@ -67,17 +67,17 @@ namespace Microsoft.StoreServices
             _clientSecret = clientSecret;
         }
 
-        public Task<AccessToken> GetServiceAccessTokenAsync()
+        public virtual Task<AccessToken> GetServiceAccessTokenAsync()
         {
             return CreateAccessTokenAsync(AccessTokenAudienceTypes.Service);
         }
 
-        public Task<AccessToken> GetCollectionsAccessTokenAsync()
+        public virtual Task<AccessToken> GetCollectionsAccessTokenAsync()
         {
             return CreateAccessTokenAsync(AccessTokenAudienceTypes.Collections);
         }
 
-        public Task<AccessToken> GetPurchaseAccessTokenAsync()
+        public virtual Task<AccessToken> GetPurchaseAccessTokenAsync()
         {
             return CreateAccessTokenAsync(AccessTokenAudienceTypes.Purchase);
         }

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/CachedAccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/CachedAccessTokenProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.StoreServices
         /// Gets the currently cached Service access token or generates a new one if not cached.
         /// </summary>
         /// <returns></returns>
-        new public Task<AccessToken> GetServiceAccessTokenAsync()
+        public override Task<AccessToken> GetServiceAccessTokenAsync()
         {
             return GetTokenAsync(AccessTokenAudienceTypes.Service);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.StoreServices
         /// Gets the currently cached Collections access token or generates a new one if not cached.
         /// </summary>
         /// <returns></returns>
-        new public Task<AccessToken> GetCollectionsAccessTokenAsync()
+        public override Task<AccessToken> GetCollectionsAccessTokenAsync()
         {
             return GetTokenAsync(AccessTokenAudienceTypes.Collections);
         }
@@ -63,7 +63,7 @@ namespace Microsoft.StoreServices
         /// Gets the currently cached Purchase access token or generates a new one if not cached.
         /// </summary>
         /// <returns></returns>
-        new public Task<AccessToken> GetPurchaseAccessTokenAsync()
+        public override Task<AccessToken> GetPurchaseAccessTokenAsync()
         {
             return GetTokenAsync(AccessTokenAudienceTypes.Purchase);
         }


### PR DESCRIPTION
the 'new' declaration for the CachedAccessTokenProvider class was not working, so I changed the definition to a virtual function in the IAccessTokenProvider so that it can be overridden by the cached class.