### PR TITLE
Fixing file headers to reference the MIT liciense.

### DIFF
--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
@@ -7,7 +7,6 @@
 // license information.
 //-----------------------------------------------------------------------------
 
-
 using Newtonsoft.Json;
 using System;
 

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
@@ -2,8 +2,11 @@
 // AccessToken.cs
 //
 // Xbox Advanced Technology Group (ATG)
-// Copyright (C) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
+
 
 using Newtonsoft.Json;
 using System;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessTokenProvider.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/CachedAccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/CachedAccessTokenProvider.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Caching.Memory;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/IAccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/IAccessTokenProvider.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System.Threading.Tasks;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreId.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreId.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdClaims.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdClaims.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdRefreshRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdRefreshRequest.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdRefreshResponse.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdRefreshResponse.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackItem.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackQueryRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackQueryRequest.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackQueryResponse.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackQueryResponse.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System.Collections.Generic;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsConsumeRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsConsumeRequest.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsConsumeResponse.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsConsumeResponse.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsItem.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsQueryRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsQueryRequest.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsQueryResponse.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsQueryResponse.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System.Collections.Generic;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/GlobalSuppressions.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/GlobalSuppressions.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 // This file is used by Code Analysis to maintain SuppressMessage

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceChangeRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceChangeRequest.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceChangeResponse.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceChangeResponse.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 namespace Microsoft.StoreServices

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceItem.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceQueryRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceQueryRequest.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceQueryResponse.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceQueryResponse.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System.Collections.Generic;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/IStoreServicesClient.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/IStoreServicesClient.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Clawback.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Clawback.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Collections.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Collections.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Recurrence.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Recurrence.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClientFactory/IStoreServicesClientFactory.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClientFactory/IStoreServicesClientFactory.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 namespace Microsoft.StoreServices

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClientFactory/StoreServicesClientFactory.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClientFactory/StoreServicesClientFactory.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System;

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesException.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesException.cs
@@ -3,6 +3,8 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License file under the project root for
+// license information.
 //-----------------------------------------------------------------------------
 
 using System;


### PR DESCRIPTION
Addressing community feedback that the MIT license was not referenced in the header files as it should be to ensure it is usable by the community. See https://github.com/microsoft/Microsoft-Store-Services/issues/6#issuecomment-867173527.

