### PR TITLE
1.21.09 Update.  Dev feedback and integration with client sample

### DIFF
--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
@@ -24,28 +24,27 @@ namespace Microsoft.StoreServices
     /// </summary>
     public class AccessToken
     {
-        /// <summary>
-        /// Lifetime of the token in seconds from when it was created
-        /// </summary>
-        [JsonProperty("expires_in")] public uint ExpiresIn { get; set; }
+        private uint expiresIn;
 
         /// <summary>
         /// Lifetime of the token in seconds from when it was created
         /// </summary>
-        [JsonProperty("ext_expires_in")] public uint ExtExpiredIn { get; set; }
+        [JsonProperty("expires_in")] public uint ExpiresIn
+        {
+            get { return expiresIn; }
 
-        /// <summary>
-        /// Seconds from the Unix Epoc that represents the UTC datetime the token will expire
-        /// </summary>
-        [JsonProperty("expires_on")] public uint EpochExpiresOn { get; set; }
-
-        /// <summary>
-        /// Seconds from the Unix Epoc that represents the UTC datetime the token starts being valid and can be used.
-        /// </summary>
-        [JsonProperty("not_before")] public uint EpochValidAfter { get; set; }
+            //  The Azure AAD 2.0 URI only includes the expires_in time value so we need to
+            //  generate the ExpiresOn value based off of it and when this was created.
+            set
+            {
+                expiresIn = value;
+                ExpiresOn = DateTimeOffset.Now.AddSeconds(value);
+            }
+        }
 
         /// <summary>
         /// Audience URI tied to the token which determines its type and which Microsoft Store Service it can be used with.
+        /// With the Azure AD URI 1.0 this was returned in the result, with 2.0 it is not and needs to be set manually.
         /// </summary>
         [JsonProperty("resource")] public string Audience { get; set; }
         
@@ -57,12 +56,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date and time when the Access Token expires
         /// </summary>
-        public DateTimeOffset ExpiresOn => DateTime.UnixEpoch.AddSeconds(EpochExpiresOn);
-
-        /// <summary>
-        /// The UTC date and time when the Access Token becomes valid and can be used
-        /// </summary>
-        public DateTimeOffset ValidAfter => DateTime.UnixEpoch.AddSeconds(EpochValidAfter);
+        public DateTimeOffset ExpiresOn { get; set; }
     }
 
     /// <summary>

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessToken.cs
@@ -57,12 +57,12 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date and time when the Access Token expires
         /// </summary>
-        public DateTime ExpiresOn => DateTime.UnixEpoch.AddSeconds(EpochExpiresOn);
+        public DateTimeOffset ExpiresOn => DateTime.UnixEpoch.AddSeconds(EpochExpiresOn);
 
         /// <summary>
         /// The UTC date and time when the Access Token becomes valid and can be used
         /// </summary>
-        public DateTime ValidAfter => DateTime.UnixEpoch.AddSeconds(EpochValidAfter);
+        public DateTimeOffset ValidAfter => DateTime.UnixEpoch.AddSeconds(EpochValidAfter);
     }
 
     /// <summary>

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/AccessTokenProvider.cs
@@ -96,11 +96,16 @@ namespace Microsoft.StoreServices
                 throw new ArgumentException($"{nameof(audience)} required", nameof(audience));
             }
 
+            //  URL encode the Secret key to ensure it gets properly transmitted if containing
+            //  characters such as '%'.  We just encode the secret so the rest of the body is
+            //  easily read in debugging tools such as Fiddler.
+            var encodedSecret = System.Web.HttpUtility.UrlEncode(_clientSecret);
+
             //  Build the HTTP request information to generate the access token
-            var requestUri = $"https://login.microsoftonline.com/{_tenantId}/oauth2/token";
+            var requestUri = $"https://login.microsoftonline.com/{_tenantId}/oauth2/v2.0/token";
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, requestUri.ToString());
             var requestBody = $"grant_type=client_credentials&client_id={_clientId}" +
-                              $"&client_secret={_clientSecret}" +
+                              $"&client_secret={encodedSecret}" +
                               $"&resource={audience}";
             httpRequest.Content = new StringContent(requestBody, Encoding.UTF8, "application/x-www-form-urlencoded");
 

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/CachedAccessTokenProvider.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/CachedAccessTokenProvider.cs
@@ -76,12 +76,12 @@ namespace Microsoft.StoreServices
         /// <returns></returns>
         protected async Task<AccessToken> GetTokenAsync(string audience)
         {
-            var currentUTC = DateTime.Now.ToUniversalTime();
+            var currentUTC = DateTime.UtcNow;
 
             //  If we are unable to acquire a token, it is expired, or expiring
             //  in less than 5 minutes we create a new one and cache it
             if(!_serverCache.TryGetValue(audience, out AccessToken token) ||
-               DateTime.Compare(token.ExpiresOn.AddMinutes(-5), currentUTC) <= 0)
+               (token.ExpiresOn.AddMinutes(-5)) <= currentUTC)
             {
                 token = await CreateAccessTokenAsync(audience);
                 CacheAccessToken(audience, token);

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreId.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreId.cs
@@ -59,9 +59,16 @@ namespace Microsoft.StoreServices
         public UserStoreIdType KeyType { get; set; }
 
         /// <summary>
-        /// UTC date time when the key will expire and need to be refreshed.
+        /// UTC date time when the key will expire, this is longer than the recommended
+        /// refresh time which we track with RefreshAfter
         /// </summary>
-        public DateTime Expires { get; set; }
+        public DateTimeOffset Expires { get; set; }
+
+        /// <summary>
+        /// UTC date that you should refresh the token to ensure it stays valid
+        /// which is every 2 weeks.
+        /// </summary>
+        public DateTimeOffset RefreshAfter { get; set; }
         
         /// <summary>
         /// The UserStoreId that was used to generate this object and would be
@@ -86,6 +93,9 @@ namespace Microsoft.StoreServices
             RefreshUri = keyClaims.RefreshUri;
             Expires = keyClaims.ExpiresOn;
             Key = storeIdKey;
+
+            //  Recommended time to refresh the ticket is every 2 weeks
+            RefreshAfter = keyClaims.IssuedOn.AddDays(14);
 
             if (keyClaims.Audience == UserStoreIdAudiences.UserCollectionsId)
             {

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdClaims.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Authentication/UserStoreIdClaims.cs
@@ -71,16 +71,16 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date and time when the UserStoreId becomes valid and can be used
         /// </summary>
-        public DateTime ValidAfter => DateTime.UnixEpoch.AddSeconds(EpochValidAfter);
+        public DateTimeOffset ValidAfter => DateTime.UnixEpoch.AddSeconds(EpochValidAfter);
 
         /// <summary>
         /// The UTC date and time when the UserStoreId expires
         /// </summary>
-        public DateTime ExpiresOn => DateTime.UnixEpoch.AddSeconds(EpochExpiresOn);
+        public DateTimeOffset ExpiresOn => DateTime.UnixEpoch.AddSeconds(EpochExpiresOn);
 
         /// <summary>
         /// The UTC date and time when the UserStoreId was created
         /// </summary>
-        public DateTime IssuedOn => DateTime.UnixEpoch.AddSeconds(EpochIssuedOn);
+        public DateTimeOffset IssuedOn => DateTime.UnixEpoch.AddSeconds(EpochIssuedOn);
     }
 }

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Clawback/ClawbackItem.cs
@@ -31,12 +31,12 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// UTC date time when the purchase transaction was made.
         /// </summary>
-        [JsonProperty("orderPurchasedDate")] public DateTime OrderPurchaseDate { get; set;}
+        [JsonProperty("orderPurchasedDate")] public DateTimeOffset OrderPurchaseDate { get; set;}
 
         /// <summary>
         /// UTC date time when the purchase was refunded (if in a refunded state).
         /// </summary>
-        [JsonProperty("orderRefundedDate")] public DateTime OrderRefundedDate { get; set;}
+        [JsonProperty("orderRefundedDate")] public DateTimeOffset OrderRefundedDate { get; set;}
 
     }
     

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsConsumeRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsConsumeRequest.cs
@@ -38,5 +38,22 @@ namespace Microsoft.StoreServices
         /// Quantity to be removed from the user's balance of the consumable product.
         /// </summary>
         [JsonProperty("removeQuantity")] public uint RemoveQuantity { get; set; }
+
+        /// <summary>
+        /// Used to determine if this is a managed or unmanaged consumable as the consume request JSON is different
+        /// between them.
+        /// </summary>
+        [JsonIgnore] public bool IsUnmanagedConsumable { get; set; }
+
+        /// <summary>
+        /// If this is an unmanaged consumable, then we don't want to add the 'removeQuantity' parameter.  Unmanaged
+        /// are always qty of 1 and the request will fail if we pass in any value for 'removeQuantity'.
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldSerializeRemoveQuantity()
+        {
+            // don't serialize the Manager property if an employee is their own manager
+            return !IsUnmanagedConsumable;
+        }
     }
 }

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsItem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The date on which the user acquired the item.
         /// </summary>
-        [JsonProperty("acquiredDate")] public DateTime AcquiredDate { get; set; }
+        [JsonProperty("acquiredDate")] public DateTimeOffset AcquiredDate { get; set; }
 
         /// <summary>
         /// Indicates how the user has this entitlement.
@@ -29,7 +29,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date that the item will expire.
         /// </summary>
-        [JsonProperty("endDate")] public DateTime EndDate { get; set; }
+        [JsonProperty("endDate")] public DateTimeOffset EndDate { get; set; }
 
         /// <summary>
         /// An ID that identifies this collection item from other items that the user owns. This ID is unique per product.
@@ -57,7 +57,7 @@ namespace Microsoft.StoreServices
         /// The UTC date that this item was last modified. With consumable products, this value changes when the user’s quantity
         /// balance changes through an additional purchase of the consumable product or when a consume request is issued.
         /// </summary>
-        [JsonProperty("modifiedDate")] public DateTime ModifiedDate { get; set; }
+        [JsonProperty("modifiedDate")] public DateTimeOffset ModifiedDate { get; set; }
 
         /// <summary>
         /// The two-character ISO 3166 country code indicating the region store the product was acquired from.
@@ -104,7 +104,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date that the item became or will become valid.
         /// </summary>
-        [JsonProperty("startDate")] public DateTime StartDate { get; set; }
+        [JsonProperty("startDate")] public DateTimeOffset StartDate { get; set; }
 
         /// <summary>
         /// The status of the item.

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsQueryRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsQueryRequest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// Specifies which product types to return in the query results. For a list of valid values, see EntitlementFilterTypes.]
         /// </summary>
-        [JsonProperty("EntitlementFilters")] public List<string> EntitlementFilters { get; set; }
+        [JsonProperty("entitlementFilters")] public List<string> EntitlementFilters { get; set; }
 
         /// <summary>
         /// If specified, the service only returns products applicable to the provided product/SKU pairs. Recommended for all service-to-service queries for faster and more reliable results.
@@ -55,6 +55,11 @@ namespace Microsoft.StoreServices
         /// </summary>
         [JsonProperty("validityType")] public string ValidityType { get; set; }
 
+        /// <summary>
+        /// Specifies which development sandbox the results should be scoped to.  If no sandbox is specified the results will always be to the sandbox RETAIL.
+        /// </summary>
+        [JsonProperty("sbx")] public string SandboxId { get; set; }
+
         public CollectionsQueryRequest()
         {
             //  default values most commonly used
@@ -70,10 +75,14 @@ namespace Microsoft.StoreServices
             EntitlementFilters = new List<string>() {
                 EntitlementFilterTypes.Game,
                 EntitlementFilterTypes.Consumable,
-                EntitlementFilterTypes.Durable
+                EntitlementFilterTypes.UnmanagedConsumable,
+                EntitlementFilterTypes.Durable,
+                EntitlementFilterTypes.Subscription
             };
 
             Beneficiaries = new List<CollectionsRequestBeneficiary>();
+
+            SandboxId = "";
         }
     }
 
@@ -151,6 +160,12 @@ namespace Microsoft.StoreServices
         /// Developer-managed consumables that must be fulfilled before being able to be purchased by the user again.
         /// </summary>
         public const string UnmanagedConsumable = "*:UnmanagedConsumable";
+
+        /// <summary>
+        /// Store-managed subscriptions. Ex: Xbox Game Pass, Publisher specific subscription.  This product type is not 
+        /// the Add-on Subscription type that can be configured in the Add-ons page in Partner Center.
+        /// </summary>
+        public const string Subscription        = "*:Pass";
     }
 
     /// <summary>

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Microsoft.StoreServices.csproj
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Microsoft.StoreServices.csproj
@@ -5,13 +5,12 @@
       <Authors>Xbox Advanced Technology Group</Authors>
       <PackageId>Microsoft.StoreServices</PackageId>
       <Company>Microsoft</Company>
-      <Version>1.0.0</Version>
+      <Version>1.21.09</Version>
       <PackageTags>Microsoft Store Services;Microsoft;Xbox</PackageTags>
-      <Description>
-          This client library enables working with the Microsoft Store Services to manage and validate user purchases within the Microsoft Store.  This library specifically has functionality to help request the needed Azure Active Directory access tokens and call the store services with this authorization.  More information can be found in the following articles:
+      <Description>This client library enables working with the Microsoft Store Services to manage and validate user purchases within the Microsoft Store.  This library specifically has functionality to help request the needed Azure Active Directory access tokens and call the store services with this authorization.  More information can be found in the following articles:
           Monetization, engagement, and Store services - https://docs.microsoft.com/en-us/windows/uwp/monetize/
           Manage product entitlements from a service - https://docs.microsoft.com/en-us/windows/uwp/monetize/view-and-grant-products-from-a-service
-      </Description>
+</Description>
       <Copyright>Copyright (C) Microsoft Corporation. All rights reserved.</Copyright>
       <PackageIcon>Logo.png</PackageIcon>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceChangeRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceChangeRequest.cs
@@ -63,5 +63,10 @@ namespace Microsoft.StoreServices
         /// If using the Extend change type, specifies how many days to add to the user's subscription.
         /// </summary>
         [JsonProperty("extensionTimeInDays")] public int ExtensionTimeInDays { get; set; }
+
+        /// <summary>
+        /// Defines the development SandboxId that results should be scoped to
+        /// </summary>
+        [JsonProperty("sbx")] public string SandboxId { get; set; }
     }
 }

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceItem.cs
@@ -30,14 +30,14 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date and time that the subscription will or has expired
         /// </summary>
-        [JsonProperty("expirationTime")] public DateTime ExpirationTime { get; set; }
+        [JsonProperty("expirationTime")] public DateTimeOffset ExpirationTime { get; set; }
 
         /// <summary>
         /// The UTC date and time that the user's Grace period will end if auto-renew fails at the 
         /// ExpirationTime.  During Grace, users should still have access and be considered valid
         /// subscribers, but notified they need to fix their auto-renew payment.
         /// </summary>
-        [JsonProperty("expirationTimeWithGrace")] public DateTime ExpirationTimeWithGrace { get; set; }
+        [JsonProperty("expirationTimeWithGrace")] public DateTimeOffset ExpirationTimeWithGrace { get; set; }
 
         /// <summary>
         /// An ID that identifies this collection item from other items that the user owns. This ID is unique per product.
@@ -52,7 +52,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date that this item was last modified.
         /// </summary>
-        [JsonProperty("lastModified")] public DateTime LastModified { get; set; }
+        [JsonProperty("lastModified")] public DateTimeOffset LastModified { get; set; }
 
         /// <summary>
         /// The country the product was purchased in following the two-character ISO 3166 country/region code. EX: US.
@@ -78,12 +78,12 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// The UTC date that the subscription became or will become valid.
         /// </summary>
-        [JsonProperty("startTime")] public DateTime StartTime { get; set; }
+        [JsonProperty("startTime")] public DateTimeOffset StartTime { get; set; }
 
         /// <summary>
         /// The UTC date that the subscription was canceled.
         /// </summary>
-        [JsonProperty("cancellationDate")] public DateTime CancellationDate { get; set; }
+        [JsonProperty("cancellationDate")] public DateTimeOffset CancellationDate { get; set; }
     }
 
     /// <summary>

--- a/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceQueryRequest.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Recurrence/RecurrenceQueryRequest.cs
@@ -18,5 +18,11 @@ namespace Microsoft.StoreServices
         /// UserPurchaseId that identifies the user we are asking about
         /// </summary>
         [JsonProperty("b2bKey")] public string UserPurchaseId { get; set; }
+
+        /// <summary>
+        /// Defines the development SandboxId that results should be scoped to
+        /// otherwise leave blank to default to RETAIL
+        /// </summary>
+        [JsonProperty("sbx")] public string SandboxId { get; set; }
     }
 }

--- a/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Recurrence.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/StoreServicesClient/StoreServicesClient.Recurrence.cs
@@ -3,7 +3,7 @@
 //
 // Xbox Advanced Technology Group (ATG)
 // Copyright (C) Microsoft Corporation. All rights reserved.
-//-----------------------------------------------------------------------------
+ //-----------------------------------------------------------------------------
 
 using Newtonsoft.Json;
 using System;


### PR DESCRIPTION
1.21.09 Update contains the following improvements:

- Switch to DateTimeOffset from community feedback
- Updated AAD Access Token generation to use the AAD 2.0 URL and format
- Added RefreshAfter value for UserStoreId to denote suggested refresh time of cached tokens (every 2 weeks) even if their expiration date is longer
- Added support for UnmanagedConsumables which have a different b2b request body for fulfillment
- Fixed typo in "entitlementFilters" to not be capitalized.
- Added sandbox supporting claims to requests (sbx)
- Added support for Pass product type (Store Managed Subscriptions)
- Updated default Collections Query to look for all product types
- Added URL encoding for AAD Client secret based on feedback