### PR TITLE
Updated to reflect actual trialtimeremaining value and structure as a timespan

### DIFF
--- a/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsItem.cs
+++ b/Microsoft.StoreServices/Microsoft.StoreServices/Collections/CollectionsItem.cs
@@ -168,7 +168,7 @@ namespace Microsoft.StoreServices
         /// <summary>
         /// Information about how long the trial remains valid.
         /// </summary>
-        [JsonProperty("trialTimeRemaining")] public string TrialTimeRemaining { get; set; }
+        [JsonProperty("trialTimeRemaining")] public TimeSpan TrialTimeRemaining { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
this was supposed to be merged a while ago, but apparently got missed.